### PR TITLE
remove azure-cli-core dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,7 @@ setup(
     install_requires=[
         "appdirs>=1.4.3", "click>=7.0", "marshmallow>=3.2.1", "pyyaml>=5.1.2",
         "azure-storage-blob>=12.3.0", "cryptography>=2.8",
-        "azure-keyvault>=4.0.0", "azure-identity>=1.3.0", "dpath>=2.0.1",
-        "azure-cli-core>=2.7.0"
+        "azure-keyvault>=4.0.0", "azure-identity>=1.3.0", "dpath>=2.0.1"
     ],
     name="victoria",
     version="0.7.7",


### PR DESCRIPTION
One more inconsistency found related to `azure-cli-core` dependency we were trying to get rid of.
Please bump the version as usual. Thank you.