### PR TITLE
fix `test_load_plugin_config_from_both` test

### DIFF
--- a/tests/victoria/test_config.py
+++ b/tests/victoria/test_config.py
@@ -284,5 +284,5 @@ plugins_config_location:
     plugin_def = victoria.plugin.Plugin("config", None, PluginSchema())
     plugin_config = victoria.config.load_plugin_config(plugin_def, config)
 
-    # plugins_config_location should take precedence over plugins_config
-    assert plugin_config["test_field"] == 2
+    # plugins_config should take precedence over plugins_config_location
+    assert plugin_config["test_field"] == 4


### PR DESCRIPTION
I discovered that one test is broken in master, this one: `test_load_plugin_config_from_both`.
Earlier there was a commit (namely 13389375dbd735db43bd035d44d05e371b8b3ea8) which altered the initial behavior of Victoria of "config file reading priority" which led to this problem.

Now that we have a new behavior it is required to update that test in order to make it pass.
Also, I updated its comment for clarity.